### PR TITLE
fix: html renderer can block worker launch

### DIFF
--- a/shared/packages/api/src/htmlRenderer.ts
+++ b/shared/packages/api/src/htmlRenderer.ts
@@ -90,12 +90,14 @@ export async function testHtmlRendererExecutable(): Promise<string | null> {
 		const executablePath = getHtmlRendererExecutable()
 		const htmlRendererProcess = spawnHtmlRendererExecutable(['--', '--test=true'], { signal })
 		let output = ''
+		let killedForMainProcessError = false
 		htmlRendererProcess.stderr.on('data', (data) => {
 			const str = data.toString()
 			output += str
 
-			if (data.includes('A JavaScript error occurred in the main process')) {
+			if (!killedForMainProcessError && output.includes('A JavaScript error occurred in the main process')) {
 				// This looks like the app itself has errored, and should be terminated
+				killedForMainProcessError = true
 				htmlRendererProcess.kill()
 			}
 		})

--- a/shared/packages/api/src/htmlRenderer.ts
+++ b/shared/packages/api/src/htmlRenderer.ts
@@ -85,12 +85,19 @@ export async function testHtmlRenderer(): Promise<string | null> {
 
 export async function testHtmlRendererExecutable(): Promise<string | null> {
 	return new Promise<string | null>((resolve) => {
+		const signal = AbortSignal.timeout(30000) // 30s timeout, to ensure it doesn't stall indefinitely as this blocks the worker startup
+
 		const executablePath = getHtmlRendererExecutable()
-		const htmlRendererProcess = spawnHtmlRendererExecutable(['--', '--test=true'])
+		const htmlRendererProcess = spawnHtmlRendererExecutable(['--', '--test=true'], { signal })
 		let output = ''
 		htmlRendererProcess.stderr.on('data', (data) => {
 			const str = data.toString()
 			output += str
+
+			if (data.includes('A JavaScript error occurred in the main process')) {
+				// This looks like the app itself has errored, and should be terminated
+				htmlRendererProcess.kill()
+			}
 		})
 		htmlRendererProcess.stdout.on('data', (data) => {
 			const str = data.toString()


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix

## Current Behavior

I was having an issue where package-manager launched, but no workers spawned. 
```
@single-app/app: [info] [single-app] ------------------------------------------------------------------
@single-app/app: [info] [single-app] Initialization complete
@single-app/app: [info] [single-app] ------------------------------------------------------------------
@single-app/app: [info] AppContainer: App "appContainer0_0" (worker): [Process] Logging to Console  {"label":""}
@single-app/app: [info] AppContainer: App "appContainer0_1" (worker): [Process] Logging to Console  {"label":""}
@single-app/app: [info] AppContainer: App "appContainer0_1" (worker): [Process] Setting log level to verbose  {"label":""}
@single-app/app: [info] AppContainer: App "appContainer0_0" (worker): [Process] Setting log level to verbose  {"label":""}
@single-app/app: [warn] AppContainer: appType "worker" not available  {"label":""}
@single-app/app: [warn] AppContainer: appType "worker" not available  {"label":""}
@single-app/app: [warn] AppContainer: appType "worker" not available  {"label":""}
```


After some trial and error in the code, this was due to it picking up an old compilation of the html-renderer, which was throwing an error when it tried to launch. This resulted in the workers getting stuck waiting for a process to exit when that process had encountered an error:

```
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): A JavaScript error occurred in the main process  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): Uncaught Exception:  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): Error: Cannot find module '@sofie-automation/shared-lib/dist/lib/status'  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): Require stack:  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): - /home/julus/Projects/bbc/sofie-package-manager/apps/html-renderer/app/deploy/linux-unpacked/resources/app.asar/node_modules/@sofie-package-manager/api/dist/inputApi.js  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): - /home/julus/Projects/bbc/sofie-package-manager/apps/html-renderer/app/deploy/linux-unpacked/resources/app.asar/node_modules/@sofie-package-manager/api/dist/index.js  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): - /home/julus/Projects/bbc/sofie-package-manager/apps/html-renderer/app/deploy/linux-unpacked/resources/app.asar/dist/index.js  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker): -   {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module._resolveFilename (node:internal/modules/cjs/loader:1151:15)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at s._resolveFilename (node:electron/js2c/browser_init:2:120292)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module._load (node:internal/modules/cjs/loader:992:27)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at c._load (node:electron/js2c/node_init:2:13672)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module.require (node:internal/modules/cjs/loader:1242:19)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at require (node:internal/modules/helpers:176:18)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Object.<anonymous> (/home/julus/Projects/bbc/sofie-package-manager/apps/html-renderer/app/deploy/linux-unpacked/resources/app.asar/node_modules/@sofie-package-manager/api/dist/inputApi.js:5:18)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module._compile (node:internal/modules/cjs/loader:1391:14)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module._extensions..js (node:internal/modules/cjs/loader:1451:10)  {"label":""}
@single-app/app: [debug] AppContainer: App "appContainer0_1" (worker):     at Module.load (node:internal/modules/cjs/loader:1214:32)  {"label":""}
```

## New Behavior

This adds 2 fixes to mitigate this;
1) Add a 30s cap for the test of the html-renderer. I don't know how long it should realistically take so maybe this could be reduced, but this is a fallback to stop it from getting stuck forever with no output.
2) Watch for `A JavaScript error occurred in the main process` to be logged, and kill the spawned process when this is encountered. 

I haven't tested these fixes, as I don't know how to recreate the broken html-renderer, but I believe both are sane and should catch the issue.

The aim of these fixes is to avoid it getting stuck with no error.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
