### PR TITLE
fix: regression in server endpoints

### DIFF
--- a/apps/http-server/packages/generic/src/server.ts
+++ b/apps/http-server/packages/generic/src/server.ts
@@ -61,7 +61,7 @@ export class PackageProxyServer {
 		await this._setUpRoutes()
 	}
 	private async _setUpRoutes(): Promise<void> {
-		this.router.all('/{/*path}', async (ctx, next) => {
+		this.router.all('/{*path}', async (ctx, next) => {
 			// Intercept and authenticate:
 
 			const apiKey: string | undefined =
@@ -95,13 +95,13 @@ export class PackageProxyServer {
 		this.router.get('/list', async (ctx) => {
 			await this.handleStorageHTMLList(ctx, async () => this.storage.listPackages())
 		})
-		this.router.get('/package/{/*path}', async (ctx) => {
+		this.router.get('/package/*path', async (ctx) => {
 			await this.handleStorage(ctx, async () => this.storage.getPackage(ctx.params.path))
 		})
-		this.router.head('/package/{/*path}', async (ctx) => {
+		this.router.head('/package/*path', async (ctx) => {
 			await this.handleStorage(ctx, async () => this.storage.headPackage(ctx.params.path))
 		})
-		this.router.post('/package/{/*path}', async (ctx) => {
+		this.router.post('/package/*path', async (ctx) => {
 			this.logger.debug(`POST ${ctx.request.URL}`)
 			const { files, fields } = await parseFormData(ctx.req, {
 				maxFileByteLength: MAX_UPLOAD_FILE_SIZE,
@@ -123,7 +123,7 @@ export class PackageProxyServer {
 				}
 			}
 		})
-		this.router.delete('/package/{/*path}', async (ctx) => {
+		this.router.delete('/package/*path', async (ctx) => {
 			this.logger.debug(`DELETE ${ctx.request.URL}`)
 			await this.handleStorage(ctx, async () => this.storage.deletePackage(ctx.params.path))
 		})
@@ -137,7 +137,7 @@ export class PackageProxyServer {
 				info: this.storage.getInfo(),
 			}
 		})
-		this.router.get('/uploadForm/{/*path}', async (ctx) => {
+		this.router.get('/uploadForm/*path', async (ctx) => {
 			// ctx.response.status = result.code
 			ctx.type = 'text/html'
 			ctx.body = (await fsReadFile(path.resolve('../static/uploadForm.html'), 'utf-8'))


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge


## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix 

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

Regression seems to have been introduced in https://github.com/Sofie-Automation/sofie-package-manager/pull/276: Some endpoints of the http server return 404, e.g. GET or POST `package/filename.mp4_thumbnail.png` does no longer return or update the thumbnail. It does only work when adding an extra slash like so: `package//filename.mp4_thumbnail.png`

## New Behavior

<!--
What is the new behavior?
-->
The bug is fixed - no extra slash needed.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
