### PR TITLE
Fix: Improve reported reasons why an expectation is not supported

### DIFF
--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations-lib.ts
@@ -238,6 +238,7 @@ export function generatePackageScan(
 		priority = expectation.priority + 1
 	}
 
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return literal<Expectation.PackageScan>({
 		id: protectString<ExpectationId>(expectation.id + '_scan'),
 		priority: priority,
@@ -253,7 +254,10 @@ export function generatePackageScan(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -278,7 +282,7 @@ export function generatePackageScan(
 			allowWaitForCPU: false,
 			removeDelay: settings.delayRemovalPackageInfo,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -286,6 +290,7 @@ export function generatePackageDeepScan(
 	expectation: SomeClipCopyExpectation,
 	settings: PackageManagerSettings
 ): Expectation.PackageDeepScan {
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return literal<Expectation.PackageDeepScan>({
 		id: protectString<ExpectationId>(expectation.id + '_deepscan'),
 		priority: expectation.priority + PriorityAdditions.DEEP_SCAN,
@@ -301,7 +306,9 @@ export function generatePackageDeepScan(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -332,7 +339,7 @@ export function generatePackageDeepScan(
 			usesCPUCount: 1,
 			removeDelay: settings.delayRemovalPackageInfo,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -342,6 +349,7 @@ export function generatePackageLoudness(
 	packageSettings: ExpectedPackage.SideEffectLoudnessSettings,
 	settings: PackageManagerSettings
 ): Expectation.PackageLoudnessScan {
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return literal<Expectation.PackageLoudnessScan>({
 		id: protectString<ExpectationId>(expectation.id + '_loudness'),
 		priority: expectation.priority + PriorityAdditions.LOUDNESS_SCAN,
@@ -357,7 +365,9 @@ export function generatePackageLoudness(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -387,7 +397,7 @@ export function generatePackageLoudness(
 			usesCPUCount: 1,
 			removeDelay: settings.delayRemovalPackageInfo,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -396,6 +406,7 @@ export function generatePackageIframes(
 	expectation: SomeClipCopyExpectation,
 	settings: PackageManagerSettings
 ): Expectation.PackageIframesScan {
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return {
 		id: protectString<ExpectationId>(expectation.id + '_iframes'),
 		priority: expectation.priority + PriorityAdditions.IFRAMES_SCAN,
@@ -411,7 +422,9 @@ export function generatePackageIframes(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -437,7 +450,7 @@ export function generatePackageIframes(
 			usesCPUCount: 1,
 			removeDelay: settings.delayRemovalPackageInfo,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	}
 }
@@ -550,6 +563,7 @@ export function generateMediaFileThumbnail(
 	settings: ExpectedPackage.SideEffectThumbnailSettings,
 	packageContainer: PackageContainer
 ): Expectation.MediaFileThumbnail {
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return literal<Expectation.MediaFileThumbnail>({
 		id: protectString<ExpectationId>(expectation.id + '_thumbnail'),
 		priority: expectation.priority + PriorityAdditions.THUMBNAIL,
@@ -565,7 +579,9 @@ export function generateMediaFileThumbnail(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -594,7 +610,7 @@ export function generateMediaFileThumbnail(
 			removeDelay: 0, // The removal of the thumbnail shouldn't be delayed
 			removePackageOnUnFulfill: true,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -604,6 +620,7 @@ export function generateMediaFilePreview(
 	settings: ExpectedPackage.SideEffectPreviewSettings,
 	packageContainer: PackageContainer
 ): Expectation.MediaFilePreview {
+	const useOnlyTargetsAsSources = expectation.type === Expectation.Type.FILE_COPY_PROXY // If previous step is to copy a proxy, we should use only that proxy as source
 	return literal<Expectation.MediaFilePreview>({
 		id: protectString<ExpectationId>(expectation.id + '_preview'),
 		priority: expectation.priority + PriorityAdditions.PREVIEW,
@@ -619,7 +636,9 @@ export function generateMediaFilePreview(
 		},
 
 		startRequirement: {
-			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
+			sources: useOnlyTargetsAsSources
+				? [...expectation.endRequirement.targets]
+				: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},
@@ -647,7 +666,7 @@ export function generateMediaFilePreview(
 			removeDelay: 0, // The removal of the preview shouldn't be delayed
 			removePackageOnUnFulfill: true,
 		},
-		dependsOnFulfilled: [expectation.id],
+		dependsOnFulfilled: useOnlyTargetsAsSources ? [expectation.id] : [],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -701,7 +720,6 @@ export function generateQuantelClipThumbnail(
 			removeDelay: 0, // The removal of the thumbnail shouldn't be delayed
 			removePackageOnUnFulfill: true,
 		},
-		dependsOnFulfilled: [expectation.id],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -756,7 +774,6 @@ export function generateQuantelClipPreview(
 			removeDelay: 0, // The removal of the preview shouldn't be delayed
 			removePackageOnUnFulfill: true,
 		},
-		dependsOnFulfilled: [expectation.id],
 		triggerByFulfilledIds: [expectation.id],
 	})
 }
@@ -920,7 +937,7 @@ export function generatePackageCopyFileProxy(
 		},
 
 		startRequirement: {
-			sources: expectation.endRequirement.targets,
+			sources: [...expectation.endRequirement.targets, ...expectation.startRequirement.sources],
 			content: expectation.endRequirement.content,
 			version: expectation.endRequirement.version,
 		},

--- a/shared/packages/expectationManager/src/expectationTracker/lib/trackedExpectationAPI.ts
+++ b/shared/packages/expectationManager/src/expectationTracker/lib/trackedExpectationAPI.ts
@@ -57,6 +57,11 @@ export class TrackedExpectationAPI {
 			updatedState = true
 		}
 
+		if (reason && trackedExp.session.assignedWorker) {
+			// Add Worker id to tech reason:
+			reason.tech = `${reason.tech} (Worker: ${trackedExp.session.assignedWorker.id || 'N/A'})`
+		}
+
 		if (reason && !_.isEqual(trackedExp.reason, reason)) {
 			trackedExp.reason = reason
 			updatedReason = true

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileCopy.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileCopy.ts
@@ -130,6 +130,7 @@ async function lookupCopySources(
 	exp: Expectation.FileCopy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -149,6 +150,7 @@ async function lookupCopyTargets(
 	exp: Expectation.FileCopy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileCopyProxy.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileCopyProxy.ts
@@ -242,6 +242,7 @@ async function lookupCopySources(
 	exp: Expectation.FileCopyProxy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -261,6 +262,7 @@ async function lookupCopyTargets(
 	exp: Expectation.FileCopyProxy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileVerify.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/fileVerify.ts
@@ -170,6 +170,7 @@ async function lookupTargets(
 	exp: Expectation.FileVerify
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/jsonDataCopy.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/jsonDataCopy.ts
@@ -411,6 +411,7 @@ async function lookupCopySources(
 	exp: Expectation.JsonDataCopy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -429,6 +430,7 @@ async function lookupCopyTargets(
 	exp: Expectation.JsonDataCopy
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/kairosLoadToRam.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/kairosLoadToRam.ts
@@ -233,6 +233,7 @@ async function lookupTargets(
 	exp: Expectation.FileVerify
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
@@ -390,14 +390,11 @@ export async function lookupAccessorHandles<Metadata>(
 						continue // Maybe next accessor works?
 					}
 				}
-
-				if (errorReasons.length === 0) {
-					// All good, no need to look further:
-					return {
-						accessor: accessor,
-						handle: handle,
-						ready: true,
-					}
+				// At this point we have found an accessor that can be used!
+				return {
+					accessor: accessor,
+					handle: handle,
+					ready: true,
 				}
 			}
 			if (errorReasons.length === 0) {

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
@@ -151,6 +151,7 @@ export interface LookupChecks {
 }
 /** Go through the Accessors and return the best one that we can use for the expectation */
 export async function lookupAccessorHandles<Metadata>(
+	lookupReason: 'Source' | 'Target' | string,
 	worker: BaseWorker,
 	packageContainers: PackageContainerOnPackage[],
 	combineWithPackageContainers: PackageContainerOnPackage[],
@@ -173,7 +174,7 @@ export async function lookupAccessorHandles<Metadata>(
 		),
 	}))
 
-	return promiseTimeout<LookupPackageContainer<Metadata>>(
+	const result = await promiseTimeout<LookupPackageContainer<Metadata>>(
 		(async () => {
 			/** undefined if all good, error string otherwise */
 			const errorReasons: {
@@ -404,18 +405,24 @@ export async function lookupAccessorHandles<Metadata>(
 					accessor: undefined,
 					ready: false,
 					reason: {
-						user: 'No target found',
-						tech: 'No target found',
+						user: 'No accessor found',
+						tech: 'No accessor found',
 					},
 					knownReason: true,
 				}
 			}
+
+			const allTechReasons = errorReasons.map((e) => e.reason.tech).join(', ') // return all technical reasons
+			const allAccessors = prioritizedAccessors
+				.map((a) => `${a.packageContainer.containerId}-${a.accessorId}`)
+				.join(', ')
+
 			return {
 				accessor: undefined,
 				ready: false,
 				reason: {
 					user: errorReasons[0].reason.user, // Just return first user reason
-					tech: errorReasons.map((e) => e.reason.tech).join(', '), // return all technical reasons
+					tech: `${allTechReasons}, have asked accessors ${allAccessors}`,
 				},
 				knownReason: errorReasons.reduce((prevValue, e) => prevValue && e.knownReason, true), // It is a known reason only if all reasons are known
 			}
@@ -430,6 +437,13 @@ export async function lookupAccessorHandles<Metadata>(
 				checks,
 			})})`
 	)
+
+	if (!result.ready) {
+		// Add reason for failure:
+		result.reason.user = `${lookupReason}: ${result.reason.user}`
+		result.reason.tech = `${lookupReason}: ${result.reason.tech}`
+	}
+	return result
 }
 
 /** Converts a diff to some kind of user-readable string */

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
@@ -175,20 +175,13 @@ export async function lookupAccessorHandles<Metadata>(
 	return promiseTimeout<LookupPackageContainer<Metadata>>(
 		(async () => {
 			/** undefined if all good, error string otherwise */
-			let errorReason:
-				| undefined
-				| {
-						reason: Reason
-						knownReason: KnownReason
-				  } = {
-				reason: { user: 'No target found', tech: 'No target found' },
-				knownReason: true,
-			}
+			const errorReasons: {
+				reason: Reason
+				knownReason: KnownReason
+			}[] = []
 
 			// See if the file is available at any of the targets:
 			for (const { packageContainer, accessorId, accessor } of prioritizedAccessors) {
-				errorReason = undefined
-
 				const handle = getAccessorHandle<Metadata>(
 					worker,
 					accessorId,
@@ -201,7 +194,7 @@ export async function lookupAccessorHandles<Metadata>(
 				// Check that the accessor is valid at the most basic level:
 				const basicResult = handle.checkHandleBasic()
 				if (!basicResult.success) {
-					errorReason = {
+					errorReasons.push({
 						reason: {
 							user: `There is an issue with the Package: ${basicResult.reason.user})`,
 							tech: `${packageContainer.label}: Accessor "${accessor.label || accessorId}": ${
@@ -209,7 +202,7 @@ export async function lookupAccessorHandles<Metadata>(
 							}`,
 						},
 						knownReason: basicResult.knownReason,
-					}
+					})
 
 					continue // Maybe next accessor works?
 				}
@@ -218,7 +211,7 @@ export async function lookupAccessorHandles<Metadata>(
 					// Check that the accessor-handle supports reading:
 					const readResult = handle.checkHandleRead()
 					if (!readResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: `There is an issue with the configuration for the PackageContainer "${
 									packageContainer.label
@@ -228,7 +221,7 @@ export async function lookupAccessorHandles<Metadata>(
 								}`,
 							},
 							knownReason: readResult.knownReason,
-						}
+						})
 						continue // Maybe next accessor works?
 					}
 				}
@@ -247,7 +240,7 @@ export async function lookupAccessorHandles<Metadata>(
 					}
 				}
 				if (!foundACompatibleAccessor) {
-					errorReason = {
+					errorReasons.push({
 						reason: {
 							user: `No accessor source/target combination found`,
 							tech: `${packageContainer.label}: Accessor "${
@@ -255,7 +248,7 @@ export async function lookupAccessorHandles<Metadata>(
 							}" is not compatible with any of the accessors for the other PackageContainers`,
 						},
 						knownReason: true,
-					}
+					})
 					continue // Maybe next accessor works?
 				}
 
@@ -273,7 +266,7 @@ export async function lookupAccessorHandles<Metadata>(
 							)}`
 					)
 					if (!readResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: `Can't read the Package from PackageContainer "${
 									packageContainer.label
@@ -283,7 +276,7 @@ export async function lookupAccessorHandles<Metadata>(
 								}`,
 							},
 							knownReason: readResult.knownReason,
-						}
+						})
 
 						continue // Maybe next accessor works?
 					}
@@ -305,7 +298,7 @@ export async function lookupAccessorHandles<Metadata>(
 
 					const compareVersionResult = compareActualExpectVersions(actualSourceVersion, checks.packageVersion)
 					if (!compareVersionResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: `Won't read from the package, due to: ${compareVersionResult.reason.user}`,
 								tech: `${packageContainer.label}: Accessor "${accessor.label || accessorId}": ${
@@ -313,7 +306,7 @@ export async function lookupAccessorHandles<Metadata>(
 								}`,
 							},
 							knownReason: compareVersionResult.knownReason,
-						}
+						})
 						continue // Maybe next accessor works?
 					}
 				}
@@ -322,7 +315,7 @@ export async function lookupAccessorHandles<Metadata>(
 					// Check that the accessor-handle supports writing:
 					const writeResult = handle.checkHandleWrite()
 					if (!writeResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: `There is an issue with the configuration for the PackageContainer "${
 									packageContainer.label
@@ -332,7 +325,7 @@ export async function lookupAccessorHandles<Metadata>(
 								}": ${writeResult.reason.tech}`,
 							},
 							knownReason: writeResult.knownReason,
-						}
+						})
 						continue // Maybe next accessor works?
 					}
 				}
@@ -352,7 +345,7 @@ export async function lookupAccessorHandles<Metadata>(
 					)
 
 					if (!writeAccessResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: `Can't write to the PackageContainer "${packageContainer.label}" (on accessor "${
 									accessor.label || accessorId
@@ -362,7 +355,7 @@ export async function lookupAccessorHandles<Metadata>(
 								}`,
 							},
 							knownReason: writeAccessResult.knownReason,
-						}
+						})
 						continue // Maybe next accessor works?
 					}
 				}
@@ -370,18 +363,18 @@ export async function lookupAccessorHandles<Metadata>(
 				if (typeof checks.customCheck === 'function') {
 					const checkResult = checks.customCheck(packageContainer, accessorId, accessor)
 					if (!checkResult.success) {
-						errorReason = {
+						errorReasons.push({
 							reason: {
 								user: checkResult.reason.user,
 								tech: checkResult.reason.tech,
 							},
 							knownReason: checkResult.knownReason,
-						}
+						})
 						continue // Maybe next accessor works?
 					}
 				}
 
-				if (!errorReason) {
+				if (errorReasons.length === 0) {
 					// All good, no need to look further:
 					return {
 						accessor: accessor,
@@ -390,11 +383,25 @@ export async function lookupAccessorHandles<Metadata>(
 					}
 				}
 			}
+			if (errorReasons.length === 0) {
+				return {
+					accessor: undefined,
+					ready: false,
+					reason: {
+						user: 'No target found',
+						tech: 'No target found',
+					},
+					knownReason: true,
+				}
+			}
 			return {
 				accessor: undefined,
 				ready: false,
-				reason: errorReason?.reason,
-				knownReason: errorReason?.knownReason,
+				reason: {
+					user: errorReasons[0].reason.user, // Just return first user reason
+					tech: errorReasons.map((e) => e.reason.tech).join(', '), // return all technical reasons
+				},
+				knownReason: errorReasons.reduce((prevValue, e) => prevValue && e.knownReason, true), // It is a known reason only if all reasons are known
 			}
 		})(),
 		INNER_ACTION_TIMEOUT,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/lib.ts
@@ -1,5 +1,6 @@
 import {
 	getAccessorHandle,
+	getAccessorStaticHandle,
 	isFileShareAccessorHandle,
 	isFTPAccessorHandle,
 	isHTTPProxyAccessorHandle,
@@ -190,6 +191,21 @@ export async function lookupAccessorHandles<Metadata>(
 					expectationContent,
 					expectationWorkOptions
 				)
+				const staticHandle = getAccessorStaticHandle(accessor)
+
+				// Check that the accessor is supported by the worker:
+				if (!staticHandle.doYouSupportAccess(worker, accessor)) {
+					errorReasons.push({
+						reason: {
+							user: `Accessor not supported`,
+							tech: `${packageContainer.label}: Accessor "${accessor.label || accessorId}" of type "${
+								accessor.type
+							}" is not supported by the worker`,
+						},
+						knownReason: true,
+					})
+					continue // Maybe next accessor works?
+				}
 
 				// Check that the accessor is valid at the most basic level:
 				const basicResult = handle.checkHandleBasic()

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
@@ -353,6 +353,7 @@ async function lookupConvertSources(
 	exp: Expectation.MediaFileConvert
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -371,6 +372,7 @@ async function lookupConvertTargets(
 	exp: Expectation.MediaFileConvert
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,
@@ -794,6 +796,7 @@ class MediaConversionOperation {
 		const sourcePath = await this.getAccessorFullPath(operationPointer.lookup.handle)
 
 		const localLookup = await this.lookupLocalAccessorHandle(
+			'Source',
 			[localPackageContainer.packageContainer],
 			path.basename(sourcePath),
 			operationPointer
@@ -890,6 +893,7 @@ class MediaConversionOperation {
 			else fileName = path.basename(this.exp.endRequirement.content.filePath)
 
 			const localLookup = await this.lookupLocalAccessorHandle(
+				'Intermediate Target',
 				[localPackageContainer.packageContainer],
 				fileName,
 				operationPointer
@@ -1029,6 +1033,7 @@ class MediaConversionOperation {
 	}
 
 	private async lookupLocalAccessorHandle(
+		lookupReason: string,
 		/** The PackageContainer to create an AccessorHandle for */
 		mainPackageContainers: Expectation.SpecificPackageContainerOnPackage.FileSource[],
 		/** File Name (not a full path, just the basename) */
@@ -1039,6 +1044,7 @@ class MediaConversionOperation {
 		// generate a random fileName to avoid collisions
 
 		return lookupAccessorHandles<UniversalVersion>(
+			lookupReason,
 			this.parent.worker,
 			mainPackageContainers,
 			[otherOperationPointer.packageContainer],

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFilePreview.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFilePreview.ts
@@ -411,6 +411,7 @@ async function lookupPreviewSources(
 	exp: Expectation.MediaFilePreview
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -429,6 +430,7 @@ async function lookupPreviewTargets(
 	exp: Expectation.MediaFilePreview
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileThumbnail.ts
@@ -396,6 +396,7 @@ async function lookupThumbnailSources(
 	exp: Expectation.MediaFileThumbnail
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -414,6 +415,7 @@ async function lookupThumbnailTargets(
 	exp: Expectation.MediaFileThumbnail
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageDeepScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageDeepScan.ts
@@ -390,6 +390,7 @@ async function lookupDeepScanSources(
 	exp: Expectation.PackageDeepScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -408,6 +409,7 @@ async function lookupDeepScanTargets(
 	exp: Expectation.PackageDeepScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageIframesScan.ts
@@ -316,6 +316,7 @@ async function lookupIframesSources(
 	exp: Expectation.PackageIframesScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -334,6 +335,7 @@ async function lookupIframesTargets(
 	exp: Expectation.PackageIframesScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageLoudnessScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageLoudnessScan.ts
@@ -290,6 +290,7 @@ async function lookupLoudnessSources(
 	exp: Expectation.PackageLoudnessScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -308,6 +309,7 @@ async function lookupLoudnessTargets(
 	exp: Expectation.PackageLoudnessScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageScan.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/packageScan.ts
@@ -258,6 +258,7 @@ async function lookupScanSources(
 	exp: Expectation.PackageScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -276,6 +277,7 @@ async function lookupScanTargets(
 	exp: Expectation.PackageScan
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipCopy.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipCopy.ts
@@ -322,6 +322,7 @@ async function lookupCopySources(
 	exp: Expectation.QuantelClipCopy
 ): Promise<LookupPackageContainer<QuantelMetadata>> {
 	return lookupAccessorHandles<QuantelMetadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -340,6 +341,7 @@ async function lookupCopyTargets(
 	exp: Expectation.QuantelClipCopy
 ): Promise<LookupPackageContainer<QuantelMetadata>> {
 	return lookupAccessorHandles<QuantelMetadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipPreview.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipPreview.ts
@@ -334,6 +334,7 @@ async function lookupPreviewSources(
 	exp: Expectation.QuantelClipPreview
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -352,6 +353,7 @@ async function lookupPreviewTargets(
 	exp: Expectation.QuantelClipPreview
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipThumbnail.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/quantelClipThumbnail.ts
@@ -386,6 +386,7 @@ async function lookupThumbnailSources(
 	exp: Expectation.QuantelClipThumbnail
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -404,6 +405,7 @@ async function lookupThumbnailTargets(
 	exp: Expectation.QuantelClipThumbnail
 ): Promise<LookupPackageContainer<Metadata>> {
 	return lookupAccessorHandles<Metadata>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/renderHTML.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/renderHTML.ts
@@ -339,6 +339,7 @@ async function lookupSources(
 	exp: Expectation.RenderHTML
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Source',
 		worker,
 		exp.startRequirement.sources,
 		exp.endRequirement.targets,
@@ -358,6 +359,7 @@ async function lookupTargets(
 	filePath: string
 ): Promise<LookupPackageContainer<UniversalVersion>> {
 	return lookupAccessorHandles<UniversalVersion>(
+		'Target',
 		worker,
 		exp.endRequirement.targets,
 		exp.startRequirement.sources,

--- a/shared/packages/worker/src/worker/workers/genericWorker/packageContainerExpectationHandler.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/packageContainerExpectationHandler.ts
@@ -108,6 +108,7 @@ async function lookupPackageContainer(
 	}
 
 	return (await lookupAccessorHandles(
+		forWhat,
 		worker,
 		packageContainers,
 		[],


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Feature / Code improvement

## Current Behavior

If an expectation has multiple source/target packageContainer/Accessors and none fits, only the first reason why is reported back to user.

## New Behavior

If an expectation has multiple source/target packageContainer/Accessors and none fits, all reasons why are included in the `tech` reason reported to the user.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
