### PR TITLE
Fix: Add media-convert keywords

### DIFF
--- a/shared/packages/api/src/inputApi.ts
+++ b/shared/packages/api/src/inputApi.ts
@@ -201,6 +201,16 @@ export namespace ExpectedPackage {
 		 */
 		needsLocalTarget?: boolean
 
+		/** When set, require keywords to be present in the stdOut output of the executable, in order for the conversion to be considered successful. */
+		requiredStdOut?: string[]
+		/** When set, require keywords to be present in the stdErr output of the executable, in order for the conversion to be considered successful. */
+		requiredStdErr?: string[]
+
+		/** When set, require keywords to NOT be present in the stdOut output of the executable, in order for the conversion to be considered successful. */
+		forbiddenStdOut?: string[]
+		/** When set, require keywords to NOT be present in the stdErr output of the executable, in order for the conversion to be considered successful. */
+		forbiddenStdErr?: string[]
+
 		/**
 		 * Force the output filename from this step.
 		 * This can be useful in multi-step scenarios where you want to specify the inter-step filename.

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
@@ -971,11 +971,11 @@ class MediaConversionOperation {
 							if (this.conversion.forbiddenStdErr?.length) {
 								this.requireNoStringsInProcessOutput(recordStdErr, this.conversion.forbiddenStdErr)
 							}
+
+							resolve()
 						} catch (err) {
 							reject(err)
 						}
-
-						resolve()
 					},
 					(err) => {
 						// On Error
@@ -1003,14 +1003,6 @@ class MediaConversionOperation {
 					})
 				}
 			})
-
-			// this.spawnedProcess?.execProcess.stdout.on('data', (data) => {
-			// 	const str = data.toString()
-			// 	log?.(`${processName}.stdout: ${str}`)
-
-			// 	lastFewLines.push(str)
-			// 	if (lastFewLines.length > 10) lastFewLines.shift()
-			// })
 		} finally {
 			this.spawnedProcess = undefined
 		}
@@ -1121,7 +1113,6 @@ class MediaConversionOperation {
 
 		for (const forbiddenStr of forbiddenStrings) {
 			if (recordStdOut.some((line) => line.includes(forbiddenStr))) {
-				// Throw a string here, as a thrown string is handled by the caller:
 				throw new Error(
 					`Forbidden string "${forbiddenStr}" found in stdout. Recorded stdout:\n${this.limitToLastFewLines(
 						recordStdOut,

--- a/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/expectationHandlers/mediaFileConvert.ts
@@ -951,11 +951,30 @@ class MediaConversionOperation {
 
 		try {
 			await new Promise<void>((resolve, reject) => {
+				const recordStdOut: string[] = []
+				const recordStdErr: string[] = []
 				this.spawnedProcess = spawnProcess(
 					executable,
 					args,
 					() => {
 						// On Done
+						try {
+							if (this.conversion.requiredStdOut?.length) {
+								this.requireStringsInProcessOutput(recordStdOut, this.conversion.requiredStdOut)
+							}
+							if (this.conversion.forbiddenStdOut?.length) {
+								this.requireNoStringsInProcessOutput(recordStdOut, this.conversion.forbiddenStdOut)
+							}
+							if (this.conversion.requiredStdErr?.length) {
+								this.requireStringsInProcessOutput(recordStdErr, this.conversion.requiredStdErr)
+							}
+							if (this.conversion.forbiddenStdErr?.length) {
+								this.requireNoStringsInProcessOutput(recordStdErr, this.conversion.forbiddenStdErr)
+							}
+						} catch (err) {
+							reject(err)
+						}
+
 						resolve()
 					},
 					(err) => {
@@ -968,7 +987,30 @@ class MediaConversionOperation {
 					}
 					// this.logger.silly
 				)
+
+				// Only collect stdout if needed:
+				if (this.conversion.requiredStdOut?.length || this.conversion.forbiddenStdOut?.length) {
+					this.spawnedProcess.execProcess.stdout.on('data', (data: Buffer) => {
+						const str = data.toString()
+						recordStdOut.push(str)
+					})
+				}
+				// Only collect stderr if needed:
+				if (this.conversion.requiredStdErr?.length || this.conversion.forbiddenStdErr?.length) {
+					this.spawnedProcess.execProcess.stderr.on('data', (data: Buffer) => {
+						const str = data.toString()
+						recordStdErr.push(str)
+					})
+				}
 			})
+
+			// this.spawnedProcess?.execProcess.stdout.on('data', (data) => {
+			// 	const str = data.toString()
+			// 	log?.(`${processName}.stdout: ${str}`)
+
+			// 	lastFewLines.push(str)
+			// 	if (lastFewLines.length > 10) lastFewLines.shift()
+			// })
 		} finally {
 			this.spawnedProcess = undefined
 		}
@@ -1055,6 +1097,39 @@ class MediaConversionOperation {
 				writePackageContainer: true,
 			}
 		)
+	}
+
+	private limitToLastFewLines(lines: string[], maxLines: number): string {
+		return lines.slice(-maxLines).join('\n')
+	}
+	private requireStringsInProcessOutput(recordStdOut: string[], requiredStrings: string[] | undefined) {
+		if (!requiredStrings?.length) return
+
+		for (const requiredStr of requiredStrings) {
+			if (!recordStdOut.some((line) => line.includes(requiredStr))) {
+				throw new Error(
+					`Required string "${requiredStr}" not found in stdout. Recorded stdout:\n${this.limitToLastFewLines(
+						recordStdOut,
+						10
+					)}`
+				)
+			}
+		}
+	}
+	private requireNoStringsInProcessOutput(recordStdOut: string[], forbiddenStrings: string[] | undefined) {
+		if (!forbiddenStrings?.length) return
+
+		for (const forbiddenStr of forbiddenStrings) {
+			if (recordStdOut.some((line) => line.includes(forbiddenStr))) {
+				// Throw a string here, as a thrown string is handled by the caller:
+				throw new Error(
+					`Forbidden string "${forbiddenStr}" found in stdout. Recorded stdout:\n${this.limitToLastFewLines(
+						recordStdOut,
+						10
+					)}`
+				)
+			}
+		}
 	}
 }
 /**


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Feature


## New Behavior

Adds the ability to define keywords to be required / forbidden in the output from an executable in a conversion step. This can be useful to ensure that a conversion is successful before moving on to the next step.

(This is useful since some external executable still exists with code 0 even though they weren't successful)


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
