### PR TITLE
fix: improve error message thrown from fetch

### DIFF
--- a/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
+++ b/shared/packages/worker/src/worker/accessorHandlers/lib/fetch.ts
@@ -70,6 +70,8 @@ export function fetchWithController(
 ): { response: Promise<Response>; controller: AbortController } {
 	const controller = new AbortController()
 
+	const tmpError = new Error() // Used later in troubleshooting
+
 	return {
 		response: new Promise((resolve, reject) => {
 			const refreshTimeout = () => {
@@ -112,13 +114,29 @@ export function fetchWithController(
 					// We should try again once as it often is a temporary issue:
 
 					doTheFetch().catch((err) => {
-						reject(err)
+						reject(handleError(err, tmpError.stack, url, options?.method))
 					})
 				} else {
-					reject(err)
+					reject(handleError(err, tmpError.stack, url, options?.method))
 				}
 			})
 		}),
 		controller,
+	}
+}
+function handleError(err: unknown, orgStack: string | undefined, url: string, method?: string) {
+	// Improve errors with the url and method info, and make sure the stack trace is preserved:
+	if (err instanceof Error) {
+		err.message = `Error when fetching ${method ?? ''} "${url}": ${err.message}`
+
+		const stackLines: string[] = [
+			...(err.stack?.split('\n').slice(1) ?? []),
+			'Original stack:',
+			...(orgStack?.split('\n') ?? []),
+		]
+		err.stack = `${err.name}: ${err.message}\n${stackLines.join('\n')}`
+		return err
+	} else {
+		return err
 	}
 }


### PR DESCRIPTION
Background: I noticed in the logs that some errors doesn't contain a stack useful for troubleshooting (AbortError)

## About Me

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix 

## Current Behavior

Got unhelpful error message stack:

```
AbortError: The user aborted a request., AbortError: The user aborted a request.
 at abort (\node_modules\node-fetch\lib\index.js:1458:16)
 at EventTarget.abortAndFinalize (\node_modules\node-fetch\lib\index.js:1473:4)
 at [nodejs.internal.kHybridDispatch] (node:internal/event_target:786:20)
 at EventTarget.dispatchEvent (node:internal/event_target:721:26)
 at abortSignal (node:internal/abort_controller:369:10)
 at Timeout._onTimeout (node:internal/abort_controller:126:7)
 at listOnTimeout (node:internal/timers:569:17)
 at process.processTimers (node:internal/timers:512:7)
```

## New Behavior

Errors thrown from the `fetch` method gets original stack appended, to help with troubleshooting.


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
