### PR TITLE
fix!: make resourceId a strict requirement, when set

### DIFF
--- a/shared/packages/worker/src/worker/workers/genericWorker/lib/lib.ts
+++ b/shared/packages/worker/src/worker/workers/genericWorker/lib/lib.ts
@@ -204,15 +204,17 @@ export function getStandardCost(exp: Expectation.Any, worker: BaseWorker): Retur
  * @returns true if equal
  */
 export function compareResourceIds(
-	resourceId0?: string | number | null,
-	resourceId1?: string | number | null
+	requiredResourceId?: string | number | null,
+	availableResourceId?: string | number | null
 ): boolean {
-	// If one of them are not set, no need to do the comparison:
-	if (resourceId0 === undefined || resourceId0 === null || resourceId0 === '') return true
-	if (resourceId1 === undefined || resourceId1 === null || resourceId1 === '') return true
+	// If the required resourceId is not set, no need to do the comparison:
+	if (requiredResourceId === undefined || requiredResourceId === null || requiredResourceId === '') return true
+
+	requiredResourceId = `${requiredResourceId}`.trim() // stringify
+	if (requiredResourceId === '') return true
 
 	// Do a textual comparison
-	return `${resourceId0}` === `${resourceId1}`
+	return `${requiredResourceId}` === `${availableResourceId}`
 }
 
 export const ACCESSOR_DUMMY_CONTENT = {


### PR DESCRIPTION


## About Me

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Change in worker behavior (technically a BREAKING CHANGE)

## Current Behavior

Currently, if a `resourceId` is NOT set on a worker (using the `--resourceId` CLI option), the worker accepts any and all expectations, even the ones that have specified a `resourceId` limitation.

This is (in my opinion) a logical flaw / mistake, and does not align with how `networkId` is handled: If a `networkId` has been set on an expectation, and is lacking from the list of `--networkIds` supported by a worker, the expectation is considered unsupported by the worker.

## New Behavior

`resourceId` and `networkIds` are now treated similarly:

If an expectation has `resourceId` or `networkId` set, it is required to be set in a workers CLI options to be supported by that worker.

**THIS IS TECHNICALLY A BREAKING CHANGE** as it changes the behavior of a worker, though I hope that this is an okay change to make.


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
