### PR TITLE
fix: activeRundown handling

### DIFF
--- a/apps/package-manager/packages/generic/src/fakeCore.ts
+++ b/apps/package-manager/packages/generic/src/fakeCore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-extraneous-import */
-import { ExternalPeripheralDeviceAPI } from '@sofie-automation/server-core-integration/dist/lib/methods'
+import { ExternalPeripheralDeviceAPI } from '@sofie-automation/server-core-integration'
 import { ExpectedPackageId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import { LoggerInstance } from '@sofie-package-manager/api'
 

--- a/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
+++ b/apps/package-manager/packages/generic/src/generateExpectations/nrk/expectations.ts
@@ -435,26 +435,25 @@ function addExpectation(
 }
 /** Returns a priority for an expectation. */
 function getPriority(
-	_activeRundownMap: Map<RundownId, PackageManagerActiveRundown>,
-	_packageWrap: ExpectedPackageWrap,
+	activeRundownMap: Map<RundownId, PackageManagerActiveRundown>,
+	packageWrap: ExpectedPackageWrap,
 	exp: Expectation.Any
 ): number {
 	// Returns the initial priority, based on the expectedPackage
 
-	// HACK: This is wanted, but is causing type errors, so disable temporarily
-	// const activeRundown: PackageManagerActiveRundown | undefined = packageWrap.expectedPackage.rundownId
-	// 	? activeRundownMap.get(packageWrap.expectedPackage.rundownId)
-	// 	: undefined
+	const activeRundown: PackageManagerActiveRundown | undefined = packageWrap.expectedPackage.rundownId
+		? activeRundownMap.get(packageWrap.expectedPackage.rundownId)
+		: undefined
 
-	// if (activeRundown) {
-	// 	// The expected package is in an active rundown.
-	// 	// Earlier rundowns should have higher priority:
-	// 	return exp.priority + activeRundown._rank + PriorityMagnitude.PLAY_NOW
-	// } else {
-	// The expected package is in an inactive rundown.
-	// Make that a low priority:
-	return exp.priority + PriorityMagnitude.OTHER
-	// }
+	if (activeRundown) {
+		// The expected package is in an active rundown.
+		// Earlier rundowns should have higher priority:
+		return exp.priority + activeRundown._rank + PriorityMagnitude.PLAY_NOW
+	} else {
+		// The expected package is in an inactive rundown.
+		// Make that a low priority:
+		return exp.priority + PriorityMagnitude.OTHER
+	}
 }
 type ExpectationCollection = Record<ExpectationId, GenerateExpectation>
 

--- a/apps/package-manager/packages/generic/src/packageManager.ts
+++ b/apps/package-manager/packages/generic/src/packageManager.ts
@@ -8,6 +8,7 @@ import {
 import {
 	ExpectedPackageId as CoreExpectedPackageId,
 	ExpectedPackageWorkStatusId,
+	RundownId,
 } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import {
 	PackageManagerActivePlaylist,
@@ -1203,6 +1204,13 @@ export function deleteAllUndefinedProperties<T extends { [key: string]: any }>(o
 }
 export type ConvertExpectedPackage<E extends ExpectedPackageOrg.Base> = Omit<E, '_id' | 'sources' | 'sideEffect'> & {
 	_id: ExpectedPackageId
+
+	/**
+	 * The ID of the rundown this package belongs to, if any.
+	 * Note: This aligns with the property in the interfaces from sofie-core
+	 */
+	rundownId?: RundownId
+
 	sources: Array<
 		Omit<E['sources'][0], 'containerId' | 'accessors'> & {
 			containerId: PackageContainerId // Converts string -> PackageContainerId


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix


## New Behavior

Fixes the activeRundown handling, which was discovered to be broken by https://github.com/Sofie-Automation/sofie-package-manager/pull/285

This has to rely on some hope of types aligning, as it appears that the types between sofie-core and package-manager are not shared in a way that makes it simple to share this property definition

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
