### PR TITLE
fix: clips not found with no extensions

### DIFF
--- a/shared/packages/api/src/__tests__/filePath.spec.ts
+++ b/shared/packages/api/src/__tests__/filePath.spec.ts
@@ -47,6 +47,26 @@ describe('resolveFileWithoutExtension', () => {
 		})
 	})
 
+	test('returns found when filename has no extension', async () => {
+		touch('myclip')
+		const result = await resolveFileWithoutExtension(path.join(tmpDir, 'myclip'))
+		expect(result).toEqual({
+			result: 'found',
+			fullPath: path.join(tmpDir, 'myclip'),
+			extension: '',
+		})
+	})
+
+	test('returns found when path already includes the extension', async () => {
+		touch('myclip.mp4')
+		const result = await resolveFileWithoutExtension(path.join(tmpDir, 'myclip.mp4'))
+		expect(result).toEqual({
+			result: 'found',
+			fullPath: path.join(tmpDir, 'myclip.mp4'),
+			extension: '',
+		})
+	})
+
 	test('returns multiple when more than one file matches', async () => {
 		touch('myclip.mp4')
 		touch('myclip.mov')
@@ -56,6 +76,18 @@ describe('resolveFileWithoutExtension', () => {
 		expect(result.matches).toHaveLength(2)
 		expect(result.matches).toEqual(
 			expect.arrayContaining([path.join(tmpDir, 'myclip.mp4'), path.join(tmpDir, 'myclip.mov')])
+		)
+	})
+
+	test('returns multiple when both extensionless and extension files exist', async () => {
+		touch('myclip')
+		touch('myclip.mp4')
+		const result = await resolveFileWithoutExtension(path.join(tmpDir, 'myclip'))
+		expect(result.result).toBe('multiple')
+		if (result.result !== 'multiple') return
+		expect(result.matches).toHaveLength(2)
+		expect(result.matches).toEqual(
+			expect.arrayContaining([path.join(tmpDir, 'myclip'), path.join(tmpDir, 'myclip.mp4')])
 		)
 	})
 

--- a/shared/packages/api/src/filePath.ts
+++ b/shared/packages/api/src/filePath.ts
@@ -64,7 +64,7 @@ export async function resolveFileWithoutExtension(fullPath: string): Promise<Fil
 
 	try {
 		const files = await fsReaddir(dir)
-		const matches = files.filter((f) => f.startsWith(base + '.'))
+		const matches = files.filter((f) => f.startsWith(base + '.') || f === base)
 
 		if (matches.length === 0) {
 			return { result: 'notFound' }

--- a/shared/packages/api/src/filePath.ts
+++ b/shared/packages/api/src/filePath.ts
@@ -38,7 +38,8 @@ export type FileResolutionResult =
 /**
  * Attempts to resolve a file path by matching filenames without extensions.
  * If the exact path doesn't exist, searches for files that start with the base name
- * followed by a dot and any extension.
+ * followed by a dot and any extension. Exact basename matches (extensionless file,
+ * or input path that already includes the extension) return `extension: ''`.
  *
  * @param fullPath - The full path to the file to resolve
  * @returns A FileResolutionResult indicating whether the file was found, not found, had multiple matches, or encountered an error
@@ -57,6 +58,18 @@ export type FileResolutionResult =
  * // If both file.mp4 and file.mov exist:
  * const result = await resolveFileWithoutExtension('/path/to/file')
  * // Returns: { result: 'multiple', matches: ['/path/to/file.mp4', '/path/to/file.mov'] }
+ *
+ * @example
+ * // If looking for /path/to/file and file (no extension) exists:
+ * // Returns: { result: 'found', fullPath: '/path/to/file', extension: '' }
+ *
+ * @example
+ * // If looking for /path/to/file.mp4 and file.mp4 exists:
+ * // Returns: { result: 'found', fullPath: '/path/to/file.mp4', extension: '' }
+ *
+ * @example
+ * // If both file and file.mp4 exist:
+ * // Returns: { result: 'multiple', matches: ['/path/to/file', '/path/to/file.mp4'] }
  */
 export async function resolveFileWithoutExtension(fullPath: string): Promise<FileResolutionResult> {
 	const dir = path.dirname(fullPath)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About Me

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a: Bug fix

## Current Behavior

When `MATCH_FILENAMES_WITHOUT_EXTENSION=1` is used full path matches are ignored.

unset `MATCH_FILENAMES_WITHOUT_EXTENSION`
* `fi.le.mp4` finds `fi.le.mp4`
* `fi.le` doesn't find `fi.le.mp4`
* `fi.le` finds `fi.le`

`MATCH_FILENAMES_WITHOUT_EXTENSION=1`
* `fi.le.mp4` doesn't find `fi.le.mp4`
* `fi.le` finds `fi.le.mp4`
* `fi.le` doesn't find `fi.le`

## New Behavior

Full paths now resolve to the correct files.


When `MATCH_FILENAMES_WITHOUT_EXTENSION=1` is used full path matches are ignored.

unset `MATCH_FILENAMES_WITHOUT_EXTENSION`
* `fi.le.mp4` finds `fi.le.mp4`
* `fi.le` doesn't find `fi.le.mp4`
* `fi.le` finds `fi.le`

`MATCH_FILENAMES_WITHOUT_EXTENSION=1`
* `fi.le.mp4` finds `fi.le.mp4`
* `fi.le` finds `fi.le.mp4`
* `fi.le` finds `fi.le`

## Testing Instructions

Test the cases listed above my changing the expected path in NRCS and renaming the files in the directory observed by package manager.

## Status

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
